### PR TITLE
Use node parsing instead of bitcoinjs

### DIFF
--- a/blockchain.js
+++ b/blockchain.js
@@ -9,7 +9,7 @@ function Blockchain (emitter, db, rpc) {
   this.rpc = rpc
 }
 
-Blockchain.prototype.connect = function (blockId, _, callback) {
+Blockchain.prototype.connect = function (blockId, height, callback) {
   rpcUtil.block(this.rpc, blockId, (err, block) => {
     if (err) return callback(err)
 
@@ -45,10 +45,11 @@ Blockchain.prototype.connect = function (blockId, _, callback) {
 
       this.connect2ndOrder(block, blockId, height, callback)
     })
-  })
+  }, height === 0)
 }
 
 function box (data) {
+  if (data.length === 0) return { q1: 0, median: 0, q3: 0 }
   let quarter = (data.length / 4) | 0
   let midpoint = (data.length / 2) | 0
 
@@ -193,7 +194,7 @@ Blockchain.prototype.spentFromTxo = function (txo, callback) {
 
 Blockchain.prototype.tip = function (callback) {
   this.db.get(types.tip, {}, (err, tip) => {
-    callback(err, !err && tip.blockId)
+    callback(err, tip && tip.blockId)
   })
 }
 

--- a/blockchain.js
+++ b/blockchain.js
@@ -49,7 +49,7 @@ Blockchain.prototype.connect = function (blockId, height, callback) {
 
       this.connect2ndOrder(blockId, block, callback)
     })
-  }, height === 0)
+  })
 }
 
 function box (data) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "bitcoinjs-lib": "^3.0.0",
     "debug": "^2.6.0",
     "run-parallel": "^1.1.6",
     "typeforce": "^1.10.6",

--- a/rpc.js
+++ b/rpc.js
@@ -62,4 +62,12 @@ function block (rpc, blockId, done, forgiving) {
   })
 }
 
-module.exports = { block, transaction }
+function header (rpc, blockId, done) {
+  rpc('getblockheader', [blockId, false], (err, hex) => {
+    if (err) return done(err)
+
+    done(null, Buffer.from(hex, 'hex'))
+  })
+}
+
+module.exports = { block, header, transaction }

--- a/rpc.js
+++ b/rpc.js
@@ -1,0 +1,57 @@
+let crypto = require('crypto')
+let parallel = require('run-parallel')
+
+function sha256 (hex) {
+  return crypto.createHash('sha256')
+    .update(Buffer.from(hex, 'hex'))
+    .digest('hex')
+}
+
+function transaction (rpc, txId, next, forgiving) {
+  rpc('getrawtransaction', [txId, false], (err, txHex) => {
+    if (err) {
+      if (forgiving && /No such mempool or blockchain transaction/.test(err)) return next()
+      return next(err)
+    }
+
+    rpc('decoderawtransaction', [txHex], (err, tx) => {
+      if (err) return next(err)
+
+      tx.txBuffer = Buffer.from(txHex, 'hex')
+      tx.txId = tx.txid
+      delete tx.txid
+      tx.vin.forEach((input) => {
+        input.prevTxId = input.txid
+        delete input.txid
+      })
+      tx.vout.forEach((output) => {
+        output.scId = sha256(output.scriptPubKey.hex)
+        output.value = Math.round(output.value * 1e8)
+        output.vout = output.n
+        delete output.n
+      })
+      tx.ins = tx.vin
+      tx.outs = tx.vout
+      delete tx.vin
+      delete tx.vout
+      next(null, tx)
+    })
+  })
+}
+
+function block (rpc, blockId, done, forgiving) {
+  rpc('getblock', [blockId, true], (err, block) => {
+    if (err) return done(err)
+
+    block.transactions = []
+    parallel(block.tx.map((txId) => {
+      return (next) => transaction(rpc, txId, next, forgiving)
+    }), (err) => {
+      if (err) return done(err)
+      delete block.tx
+      done(err, block)
+    })
+  })
+}
+
+module.exports = { block, transaction }

--- a/rpc.js
+++ b/rpc.js
@@ -45,7 +45,15 @@ function block (rpc, blockId, done, forgiving) {
 
     block.transactions = []
     parallel(block.tx.map((txId) => {
-      return (next) => transaction(rpc, txId, next, forgiving)
+      return (next) => {
+        transaction(rpc, txId, (err, tx) => {
+          if (err) return next(err)
+          if (!tx) return next()
+
+          block.transactions.push(tx)
+          next()
+        }, forgiving)
+      }
     }), (err) => {
       if (err) return done(err)
       delete block.tx

--- a/types.js
+++ b/types.js
@@ -1,11 +1,8 @@
 let typeforce = require('typeforce')
-let vstruct = require('varstruct')
+let tfHex64 = typeforce.HexN(64)
 
+let vstruct = require('varstruct')
 let Hex64 = vstruct.String(32, 'hex')
-let Hex64t = typeforce.HexN(64)
-let blockId = Hex64
-let txId = Hex64
-let scId = Hex64
 let vout = vstruct.UInt32LE
 let satoshis = vstruct.UInt64LE
 
@@ -14,22 +11,26 @@ let tip = {
   key: vstruct([
     ['prefix', vstruct.Value(vstruct.UInt8, 0x00)]
   ]),
-  valueType: Hex64t,
-  value: blockId
+  valueType: {
+    blockId: tfHex64
+  },
+  value: vstruct([
+    ['blockId', Hex64]
+  ])
 }
 
 let scIndex = {
   keyType: typeforce.compile({
-    scId: Hex64t,
+    scId: tfHex64,
     height: typeforce.UInt32,
-    txId: Hex64t,
+    txId: tfHex64,
     vout: typeforce.UInt32
   }),
   key: vstruct([
     ['prefix', vstruct.Value(vstruct.UInt8, 0x01)],
-    ['scId', scId],
+    ['scId', Hex64],
     ['height', vstruct.UInt32BE], // big-endian for lexicographical sort
-    ['txId', txId],
+    ['txId', Hex64],
     ['vout', vout]
   ]),
   valueType: typeforce.Null,
@@ -38,31 +39,31 @@ let scIndex = {
 
 let spentIndex = {
   keyType: typeforce.compile({
-    txId: Hex64t,
+    txId: tfHex64,
     vout: typeforce.UInt32
   }),
   key: vstruct([
     ['prefix', vstruct.Value(vstruct.UInt8, 0x02)],
-    ['txId', txId],
+    ['txId', Hex64],
     ['vout', vout]
   ]),
   valueType: typeforce.compile({
-    txId: Hex64t,
+    txId: tfHex64,
     vin: typeforce.UInt32
   }),
   value: vstruct([
-    ['txId', txId],
+    ['txId', Hex64],
     ['vin', vout]
   ])
 }
 
 let txIndex = {
   keyType: typeforce.compile({
-    txId: Hex64t
+    txId: tfHex64
   }),
   key: vstruct([
     ['prefix', vstruct.Value(vstruct.UInt8, 0x03)],
-    ['txId', txId]
+    ['txId', Hex64]
   ]),
   valueType: typeforce.compile({
     height: typeforce.UInt32
@@ -74,12 +75,12 @@ let txIndex = {
 
 let txoIndex = {
   keyType: typeforce.compile({
-    txId: Hex64t,
+    txId: tfHex64,
     vout: typeforce.UInt32
   }),
   key: vstruct([
     ['prefix', vstruct.Value(vstruct.UInt8, 0x04)],
-    ['txId', txId],
+    ['txId', Hex64],
     ['vout', vout]
   ]),
   valueType: typeforce.compile({

--- a/types.js
+++ b/types.js
@@ -12,10 +12,12 @@ let tip = {
     ['prefix', vstruct.Value(vstruct.UInt8, 0x00)]
   ]),
   valueType: {
-    blockId: tfHex64
+    blockId: tfHex64,
+    height: typeforce.UInt32
   },
   value: vstruct([
-    ['blockId', Hex64]
+    ['blockId', Hex64],
+    ['height', vstruct.UInt32LE]
   ])
 }
 


### PR DESCRIPTION
Speed is about the same as I didn't know `getblock` had a verbosity argument to include decoded transactions. (See https://github.com/bitcoin-dot-org/bitcoin.org/pull/1769)

Database breaking change (https://github.com/bitcoinjs/indexd/pull/13/commits/87d9bc3ab103111c0edd86bec91b3f93c6b28cf3) as I changed `types.tip` type to include `height`.
Easily migrated if anyone needs to ask how.